### PR TITLE
fix: checkout release tag instead of main branch during build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0  # Fetch all history for setuptools_scm
 
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,5 @@ packages = ["func_to_script"]
 
 [tool.setuptools_scm]
 version_file = "func_to_script/_version.py"
+local_scheme = "no-local-version"
+tag_regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"


### PR DESCRIPTION
When a release is published via GitHub UI, the build job was defaulting
to the main branch instead of checking out the release tag. This caused
setuptools_scm to generate incorrect dev versions (e.g., 0.1.0.dev0)
instead of the proper release version from the tag.

This fix adds ref: ${{ github.event.release.tag_name }} to ensure the
build happens from the actual release tag, matching the fix applied to
pytorch-accelerated in PR #75.

Without this fix, published packages would have incorrect version numbers.